### PR TITLE
Fix how the timeout is set

### DIFF
--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -52,13 +52,13 @@ module OpenAI
     end
 
     def self.get(path:)
-      conn.get(uri(path: path), timeout: OpenAI.configuration.request_timeout) do |req|
+      conn.get(uri(path: path)) do |req|
         req.headers = headers
       end
     end
 
     def self.json_post(path:, parameters:)
-      conn.post(uri(path: path), timeout: OpenAI.configuration.request_timeout) do |req|
+      conn.post(uri(path: path)) do |req|
         req.headers = headers
         if parameters[:stream] && parameters[:on_data].is_a?(Proc)
           req.options.on_data = parameters[:on_data]
@@ -69,20 +69,20 @@ module OpenAI
     end
 
     def self.multipart_post(path:, parameters: nil)
-      conn.post(uri(path: path), timeout: OpenAI.configuration.request_timeout) do |req|
+      conn.post(uri(path: path)) do |req|
         req.body = parameters
         req.headers = headers.merge({ "Content-Type" => "multipart/form-data" })
       end
     end
 
     def self.delete(path:)
-      conn.delete(uri(path: path), timeout: OpenAI.configuration.request_timeout) do |req|
+      conn.delete(uri(path: path)) do |req|
         req.headers = headers
       end
     end
 
     private_class_method def self.conn
-      Faraday.new(params: nil)
+      Faraday.new(params: nil, request: { timeout: OpenAI.configuration.request_timeout })
     end
 
     private_class_method def self.uri(path:)

--- a/spec/openai/client/client_spec.rb
+++ b/spec/openai/client/client_spec.rb
@@ -6,41 +6,45 @@ RSpec.describe OpenAI::Client do
   end
 
   describe ".get" do
-    it "passes timeout as param" do
-      expect_any_instance_of(Faraday::Connection).to receive(:get).with(
-        any_args,
-        hash_including(timeout: default_timeout)
-      )
+    it "sets the timeout in the connection" do
+      expect(Faraday).to receive(:new).with(
+        hash_including(request: { timeout: default_timeout })
+      ).and_call_original
+      expect_any_instance_of(Faraday::Connection).to receive(:get)
+
       OpenAI::Client.get(path: "/abc")
     end
   end
 
   describe ".json_post" do
-    it "passes timeout as param" do
-      expect_any_instance_of(Faraday::Connection).to receive(:post).with(
-        any_args,
-        hash_including(timeout: default_timeout)
-      )
+    it "sets the timeout in the connection" do
+      expect(Faraday).to receive(:new).with(
+        hash_including(request: { timeout: default_timeout })
+      ).and_call_original
+      expect_any_instance_of(Faraday::Connection).to receive(:post)
+
       OpenAI::Client.json_post(path: "/abc", parameters: { foo: :bar })
     end
   end
 
   describe ".multipart_post" do
-    it "passes timeout as param to httparty" do
-      expect_any_instance_of(Faraday::Connection).to receive(:post).with(
-        any_args,
-        hash_including(timeout: default_timeout)
-      )
+    it "sets the timeout in the connection" do
+      expect(Faraday).to receive(:new).with(
+        hash_including(request: { timeout: default_timeout })
+      ).and_call_original
+      expect_any_instance_of(Faraday::Connection).to receive(:post)
+
       OpenAI::Client.multipart_post(path: "/abc")
     end
   end
 
   describe ".delete" do
-    it "passes timeout as param to httparty" do
-      expect_any_instance_of(Faraday::Connection).to receive(:delete).with(
-        any_args,
-        hash_including(timeout: default_timeout)
-      )
+    it "sets the timeout in the connection" do
+      expect(Faraday).to receive(:new).with(
+        hash_including(request: { timeout: default_timeout })
+      ).and_call_original
+      expect_any_instance_of(Faraday::Connection).to receive(:delete)
+
       OpenAI::Client.delete(path: "/abc")
     end
   end


### PR DESCRIPTION
This is based against https://github.com/airopshq/ruby-openai/pull/5.
What: Fix how the timeout is sent to Faraday gem


## All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
